### PR TITLE
fix: distinguish between missing prices and €0 journeys

### DIFF
--- a/components/JourneyCard/JourneyCard.tsx
+++ b/components/JourneyCard/JourneyCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { VendoJourney } from "@/utils/schemas";
+import { formatPriceDE } from "@/utils/priceUtils";
 import { getTransferStations } from "./getTransferStations";
 import { formatDate, formatTime } from "./journey-card-utils";
 import { JourneyDuration } from "./JourneyDuration";
@@ -21,8 +22,8 @@ export const JourneyCard = ({
 	const transferCountWithoutWalking = Math.max(0, nonWalkingLegs.length - 1);
 	const transferStationsWithoutWalking = getTransferStations(nonWalkingLegs);
 
-	const priceDisplay = journey.price?.amount
-		? `€${journey.price.amount.toFixed(2)}`
+	const priceDisplay = journey.price?.amount != null
+		? formatPriceDE(journey.price.amount)
 		: "Price on request";
 
 	return (

--- a/components/SplitOptions/Segment.tsx
+++ b/components/SplitOptions/Segment.tsx
@@ -10,7 +10,7 @@ import {
 	getLineInfoFromLeg,
 	getStationName,
 } from "@/utils/journeyUtils";
-import { formatPriceDE } from "./formatPriceDE";
+import { formatPriceDE } from "@/utils/priceUtils";
 
 export const Segment = ({
 	segment,
@@ -70,7 +70,11 @@ export const Segment = ({
 							{segmentHasFlixTrain ? "FlixTrain" : "Price unknown"}
 						</span>
 					) : (
-						<span>{segment.price && formatPriceDE(segment.price.amount)}</span>
+						<span>
+							{segment.price?.amount != null 
+								? formatPriceDE(segment.price.amount)
+								: "Price on request"}
+						</span>
 					)}
 				</div>
 				<button

--- a/components/SplitOptions/SplitOptions.tsx
+++ b/components/SplitOptions/SplitOptions.tsx
@@ -8,7 +8,7 @@ import {
 	formatTime,
 	getStationName,
 } from "../../utils/journeyUtils";
-import { formatPriceDE } from "./formatPriceDE";
+import { formatPriceDE } from "@/utils/priceUtils";
 import { getOptionsToShow } from "./getOptionsToShow";
 import { Segment } from "./Segment";
 

--- a/components/SplitOptions/calculateSplitOptionPricing.ts
+++ b/components/SplitOptions/calculateSplitOptionPricing.ts
@@ -71,7 +71,7 @@ export const calculateSplitOptionPricing = ({
 		let totalSegments = splitOption.segments.length;
 
 		splitOption.segments.forEach((segment, index) => {
-			const hasPrice = segment.price && segment.price.amount > 0;
+			const hasPrice = segment.price && segment.price.amount != null;
 			const segmentHasFlixTrain = getJourneyLegsWithTransfers(segment).some(
 				(leg) => legIsFlixTrain(leg)
 			);
@@ -108,7 +108,7 @@ export const calculateSplitOptionPricing = ({
 				);
 				const segmentPrice = segment.price?.amount || 0;
 
-				if (!segmentCovered && segmentPrice > 0) {
+				if (!segmentCovered && segmentPrice != null && segmentPrice > 0) {
 					totalUncoveredPrice += segmentPrice;
 				}
 			}

--- a/utils/priceUtils.ts
+++ b/utils/priceUtils.ts
@@ -1,0 +1,3 @@
+export const formatPriceDE = (price: number): string => {
+	return `${price.toFixed(2).replace(".", ",")} €`;
+};


### PR DESCRIPTION
## Summary
- Fix price display logic to properly distinguish between missing and zero prices
- `null`/`undefined` prices → "Price on request" (e.g., international routes)
- `€0` prices → "0,00 €" (e.g., Deutschland-Ticket covered routes)
- Extract price formatting to shared utility to avoid duplication

## Changes Made
- Updated price check from `price > 0` to `price != null`
- Fixed SplitOptions to handle null prices consistently
- Created shared `formatPriceDE` utility in `utils/priceUtils.js`
- Both components now use consistent German price formatting

Fixes #25