### PR TITLE
chore: add `.idea` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ dist/
 # Enviroment files
 .env
 
+# JetBrains editors
+.idea
+
 # etc
 .DS_Store


### PR DESCRIPTION
JetBrains editors automatically generate a config/settings folder called `.idea`.
Add the `.idea` folder to the `.gitignore` so developers using a JetBrains editor don't accidentally commit this folder.

