### PR TITLE
fix(issue#57): sending correct header-keys

### DIFF
--- a/utils/parseHinfahrtRecon.ts
+++ b/utils/parseHinfahrtRecon.ts
@@ -115,8 +115,8 @@ export const parseHinfahrtReconWithAPI = async (
 		schema: reconResponseSchema,
 		method: "POST",
 		headers: {
-			"content-type": "application/json",
-			cookies: cookies.join(" "),
+			"Content-Type": "application/json",
+			"Cookie": cookies.join(" "),
 		},
 		body: {
 			klasse: "KLASSE_2",


### PR DESCRIPTION
This pull-request doesn't provide a working solution for the `bm_sz`-cookie but rather fix the `415 Unsupported Media Type`-response caused by `"content-type"` and the correct keyname for `Cookie`.

https://github.com/l2xu/betterbahn/issues/57#issuecomment-3246541169