### PR TITLE
[Feature] Use cookies from webif, forward to DB API

### DIFF
--- a/utils/parseHinfahrtRecon.ts
+++ b/utils/parseHinfahrtRecon.ts
@@ -116,7 +116,7 @@ export const parseHinfahrtReconWithAPI = async (
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			"Cookie": cookies.join(" "),
+			"Cookie": cookies.join(";"),
 		},
 		body: {
 			klasse: "KLASSE_2",


### PR DESCRIPTION
with this you can simply go into dev-tools on the db site, go to "Application", then left side "Storage->Cookies->bahn.de" and copy paste them to the tab with the webif of the betterbahn server open.