### PR TITLE
fix: handle empty halte arrays in route parsing

### DIFF
--- a/app/api/parse-url/route.ts
+++ b/app/api/parse-url/route.ts
@@ -95,7 +95,7 @@ function extractJourneyDetails(url: string) {
 
 		// Extract from hash parameters (consistent approach)
 		const params = new URLSearchParams(hash.replace("#", ""));
-		
+
 		const soidValue = params.get("soid");
 		const zoidValue = params.get("zoid");
 		const dateValue = params.get("hd");
@@ -170,8 +170,22 @@ async function getResolvedUrlBrowserless(url: string) {
 
 	// Use hash parameters for consistency with DB URLs
 	const hashParams = new URLSearchParams();
-	hashParams.set("soid", data.verbindungen[0].verbindungsAbschnitte.at(0)!.halte.at(0)!.id);
-	hashParams.set("zoid", data.verbindungen[0].verbindungsAbschnitte.at(-1)!.halte.at(-1)!.id);
+
+	// Find first segment with halte data for start station
+	const firstSegmentWithHalte = data.verbindungen[0].verbindungsAbschnitte.find(
+		(segment) => segment.halte.length > 0
+	);
+	const lastSegmentWithHalte =
+		data.verbindungen[0].verbindungsAbschnitte.findLast(
+			(segment) => segment.halte.length > 0
+		);
+
+	if (!firstSegmentWithHalte || !lastSegmentWithHalte) {
+		throw new Error("No segments with station data found");
+	}
+
+	hashParams.set("soid", firstSegmentWithHalte.halte[0].id);
+	hashParams.set("zoid", lastSegmentWithHalte.halte.at(-1)!.id);
 
 	// Add date information from the booking
 	if (vbidRequest.data.hinfahrtDatum) {


### PR DESCRIPTION
**Background**
When merging #78, I accidentally introduced a regression, as @FunctionDJ pointed out.

**Problem**
The route parsing was failing with validation errors because some route segments (e.g., walking segments, transfers) legitimately had empty halte arrays. However, the code was still trying to access halte[0] on all segments without checking if station data was present.

**Root Cause**
	•	Validation schema was changed from .min(1) to .min(0) to allow empty halte arrays for walking segments.
	•	The parsing logic still assumed all segments contained station data.
	•	This mismatch caused runtime errors when encountering empty arrays.

**Solution**
The parsing logic was updated to:
	•	Filter only valid segments: Use find() and findLast() on segments where segment.halte.length > 0.
	•	Skip empty segments: Walking segments and transfers with no stops are safely ignored.
	•	Add error handling: Provide a clear error message if no valid station data is found.
	•	Safe array access: Access halte[0] and halte.at(-1) only after confirming the array contains data.

**Changes**
	•	parseHinfahrtRecon.ts: Keep .min(0) so walking segments can have empty arrays.
	•	route.ts: Update parsing logic to handle a mix of segments (some with station data, some empty).