### PR TITLE
Fix/browsify scraping

### DIFF
--- a/app/api/parse-url/route.ts
+++ b/app/api/parse-url/route.ts
@@ -171,12 +171,21 @@ async function getResolvedUrlBrowserless(url: string, clientCookies: string = ''
 		.map(cookie => cookie.split(';')[0]) // Take only the name=value part
 		.filter(cookie => cookie.trim());
 
-	const allCookies = [];
+	// Properly format cookies with semicolons and spaces between them
+	const allCookiesSet = new Set<string>();
+	
+	// Add client cookies (split and clean if needed)
 	if (clientCookies) {
-		allCookies.push(clientCookies);
+		clientCookies.split(';').forEach(cookie => {
+			const trimmed = cookie.trim();
+			if (trimmed) allCookiesSet.add(trimmed);
+		});
 	}
-	allCookies.push(...responseCookies);
-
+	
+	// Add response cookies
+	responseCookies.forEach(cookie => allCookiesSet.add(cookie));
+	
+	const allCookies = Array.from(allCookiesSet);
 	console.log("Final cookie header:", allCookies.join('; '));
 
 	const { data } = await parseHinfahrtReconWithAPI(vbidRequest.data, allCookies)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/utils/fetchAndValidateJson.ts
+++ b/utils/fetchAndValidateJson.ts
@@ -32,6 +32,24 @@ export const fetchAndValidateJson = async <
 	const response = await fetch(url, init);
 
 	if (!response.ok) {
+		if (response.status === 403) {
+			console.error(`403 Forbidden error accessing ${url}`);
+			console.error(`Request headers:`, init.headers);
+			
+			// Try to get response body for additional error details
+			let responseText = '';
+			try {
+				responseText = await response.text();
+				console.error(`Response body: ${responseText.substring(0, 500)}`);
+			} catch (e) {
+				console.error(`Could not read response body: ${e}`);
+			}
+			
+			throw new Error(
+				`Access forbidden (403) to ${url} - API may have blocked the request due to missing authentication or anti-scraping measures`
+			);
+		}
+		
 		throw new Error(
 			`Failed to fetch ${url}: ${response.status} ${response.statusText}`
 		);

--- a/utils/parseHinfahrtRecon.ts
+++ b/utils/parseHinfahrtRecon.ts
@@ -116,7 +116,15 @@ export const parseHinfahrtReconWithAPI = async (
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			"Cookie": cookies.join(";"),
+			"Cookie": cookies.join("; "),
+			"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+			"Accept": "application/json, text/plain, */*",
+			"Accept-Language": "en-US,en;q=0.9,de;q=0.8",
+			"Origin": "https://www.bahn.de",
+			"Referer": "https://www.bahn.de/buchung/fahrplan/suche",
+			"Sec-Fetch-Dest": "empty",
+			"Sec-Fetch-Mode": "cors",
+			"Sec-Fetch-Site": "same-origin",
 		},
 		body: {
 			klasse: "KLASSE_2",

--- a/utils/parseHinfahrtRecon.ts
+++ b/utils/parseHinfahrtRecon.ts
@@ -116,7 +116,7 @@ export const parseHinfahrtReconWithAPI = async (
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			"Cookie": cookies.join(" "),
+			"Cookie": cookies.join(";"),
 		},
 		body: {
 			klasse: "KLASSE_2",


### PR DESCRIPTION
# Disclamer
This PR builts on the fork of defekkt who added a cookie fix.
# Issue Description
The application was encountering 403 Forbidden errors when attempting to access the Deutsche Bahn API endpoint https://www.bahn.de/web/api/angebote/recon. This was happening specifically in the search functionality when users enter a search link in the UI.

# Root Cause
Deutsche Bahn has implemented anti-scraping protection on their APIs that detects and blocks requests that don't appear to come from a legitimate browser. Our implementation was missing proper browser-like headers and had issues with cookie handling.

# Changes Made
1. Enhanced Browser Headers in API Requests:
- Added comprehensive browser-like headers to the parseHinfahrtReconWithAPI function including:
  -  Modern User-Agent string
  - Appropriate Accept headers
  - Origin and Referer headers matching the Deutsche Bahn website
  - Security-related headers (Sec-Fetch-* series)

2. Improved Cookie Handling:

- Implemented better cookie formatting in getResolvedUrlBrowserless
- Used a Set to eliminate duplicate cookies
- Properly formatted cookies with correct separators
- Fixed spacing issues in cookie string concatenation

3. Enhanced Error Diagnostics:

- Added detailed logging for 403 responses in fetchAndValidateJson
- Included request headers in error logs for debugging
- Added response body inspection for additional error details
- Improved error messages to make troubleshooting easier

## How It Works
These changes make our application's requests appear more like legitimate browser traffic, which helps bypass Deutsche Bahn's anti-scraping measures. By properly formatting cookies and including all the headers a real browser would send, we minimize the likelihood of being detected as an automated script.