### PR TITLE
Buttons show cursor on hover and slightly change shade

### DIFF
--- a/components/SearchForm/SearchForm.tsx
+++ b/components/SearchForm/SearchForm.tsx
@@ -95,7 +95,7 @@ export const SearchForm = () => {
 				<button
 					onClick={handleUrlParsingAndNavigation}
 					disabled={!url.trim()}
-					className="w-full bg-primary text-white py-3 px-4 rounded-full hover:primaryfocus:outline-none  disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-lg font-semibold"
+					className="w-full bg-primary text-white py-3 px-4 rounded-full hover:cursor-pointer hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-lg font-semibold"
 				>
 					Bessere Verbindung suchen
 				</button>

--- a/components/SplitOptions/Segment.tsx
+++ b/components/SplitOptions/Segment.tsx
@@ -67,9 +67,8 @@ export const Segment = ({
 						</span>
 					) : hasUnknownPrice ? (
 						<span
-							className={`text-xs font-medium ${
-								segmentHasFlixTrain ? "text-purple-600" : "text-orange-600"
-							}`}
+							className={`text-xs font-medium ${segmentHasFlixTrain ? "text-purple-600" : "text-orange-600"
+								}`}
 						>
 							{segmentHasFlixTrain ? "FlixTrain" : "Price unknown"}
 						</span>
@@ -94,7 +93,7 @@ export const Segment = ({
 							alert("Failed to generate booking URL.");
 						}
 					}}
-					className="mt-1 px-3 py-1 bg-green-600 text-foreground text-xs rounded-md "
+					className="mt-1 px-3 py-1 bg-green-600 hover:bg-green-700 hover:cursor-pointer text-foreground text-xs rounded-md "
 				>
 					Zur Buchung
 				</button>


### PR DESCRIPTION
The Button "Bessere Verbindung suchern" in the main window and "Zur Buchung" now show the pointer cursor and change to a darker tone when hovered.
This looks more natural and feels intuitive.

### Before:
![before_button](https://github.com/user-attachments/assets/fc71de64-75f3-4c0a-ad36-5c3b02d91448)

### After:
![after_button](https://github.com/user-attachments/assets/aa870453-cfb0-49c3-be10-351ab7eb0f6a)
