### PR TITLE
chore: Fix linting errors and warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,4 +1,8 @@
 {
+	"env": {
+		"browser": true,
+		"node": true
+	},
 	"categories": {
 		"correctness": "error",
 		"nursery": "warn",
@@ -8,10 +12,15 @@
 	"rules": {
 		"max-lines-per-function": "off",
 		"max-lines": "off",
-		"max-depth": "off"
+		"max-depth": "off",
+		"eqeqeq": ["error", "always", { "null": "ignore" }]
 	},
-	"env": {
-		"browser": true,
-		"node": true
-	}
+	"overrides": [
+		{
+			"files": ["next-env.d.ts"],
+			"rules": {
+				"triple-slash-reference": "off"
+			}
+		}
+	]
 }

--- a/app/api/split-journey/route.ts
+++ b/app/api/split-journey/route.ts
@@ -84,7 +84,7 @@ const handler = async (request: Request) => {
 	// Gibt die Ergebnisse als JSON zurück
 	return Response.json({
 		success: true,
-		splitOptions: splitOptions.sort((a, b) => b.savings - a.savings),
+		splitOptions: splitOptions.toSorted((a, b) => b.savings - a.savings),
 		originalPrice,
 	});
 };
@@ -484,7 +484,7 @@ function handleStreamingResponse(
 				const finalData = {
 					type: "complete",
 					success: true,
-					splitOptions: splitOptions.sort((a, b) => b.savings - a.savings),
+					splitOptions: splitOptions.toSorted((a, b) => b.savings - a.savings),
 					originalPrice,
 				};
 				controller.enqueue(

--- a/components/SplitOptions/getOptionsToShow.ts
+++ b/components/SplitOptions/getOptionsToShow.ts
@@ -25,7 +25,7 @@ export const getOptionsToShow = ({
 	}));
 
 	// Sort by savings (highest first)
-	const sortedOptions = optionsWithPricing.sort(
+	const sortedOptions = optionsWithPricing.toSorted(
 		(a, b) => b.pricing.adjustedSavings - a.pricing.adjustedSavings
 	);
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/utils/journeyUtils.ts
+++ b/utils/journeyUtils.ts
@@ -121,7 +121,8 @@ export const searchForJourneys = async (
 		// Re-throw with more user-friendly message if it's a network error
 		if (typedError.message.includes("fetch")) {
 			throw new Error(
-				"Netzwerkfehler: Bitte überprüfe deine Internetverbindung"
+				"Netzwerkfehler: Bitte überprüfe deine Internetverbindung",
+				{ cause: error }
 			);
 		}
 		throw error;


### PR DESCRIPTION
**Before:**

```
❯ pnpm run oxlint

> db_ticket@0.1.0 oxlint /Users/alexander.roidl/Projects/betterbahn
> oxlint


  ⚠ eslint-plugin-unicorn(no-array-sort): Use `Array#toSorted()` instead of `Array#sort()`.
    ╭─[components/SplitOptions/getOptionsToShow.ts:28:43]
 27 │     // Sort by savings (highest first)
 28 │     const sortedOptions = optionsWithPricing.sort(
    ·                                              ────
 29 │         (a, b) => b.pricing.adjustedSavings - a.pricing.adjustedSavings
    ╰────
  help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.

  ⚠ eslint-plugin-unicorn(no-array-sort): Use `Array#toSorted()` instead of `Array#sort()`.
    ╭─[app/api/split-journey/route.ts:87:30]
 86 │         success: true,
 87 │         splitOptions: splitOptions.sort((a, b) => b.savings - a.savings),
    ·                                    ────
 88 │         originalPrice,
    ╰────
  help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.

  ⚠ eslint-plugin-unicorn(no-array-sort): Use `Array#toSorted()` instead of `Array#sort()`.
     ╭─[app/api/split-journey/route.ts:487:33]
 486 │                     success: true,
 487 │                     splitOptions: splitOptions.sort((a, b) => b.savings - a.savings),
     ·                                                ────
 488 │                     originalPrice,
     ╰────
  help: `Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.

  ⚠ eslint(preserve-caught-error): There is no cause error attached to this new thrown error.
     ╭─[utils/journeyUtils.ts:123:4]
 122 │             if (typedError.message.includes("fetch")) {
 123 │ ╭─▶             throw new Error(
 124 │ │                   "Netzwerkfehler: Bitte überprüfe deine Internetverbindung"
 125 │ ╰─▶             );
 126 │             }
     ╰────
  help: Preserve the original error by using the `cause` property when re-throwing errors.

  ⚠ eslint(eqeqeq): Expected !== and instead saw !=
    ╭─[components/SplitOptions/calculateSplitOptionPricing.ts:74:59]
 73 │         splitOption.segments.forEach((segment, index) => {
 74 │             const hasPrice = segment.price && segment.price.amount != null;
    ·                                                                    ──
 75 │             const segmentHasFlixTrain = getJourneyLegsWithTransfers(segment).some(
    ╰────
  help: Prefer !== operator

Found 5 warnings and 0 errors.
Finished in 9ms on 50 files using 8 threads.
```

**After:**

```
❯ pnpm run oxlint

> db_ticket@0.1.0 oxlint /Users/alexander.roidl/Projects/betterbahn
> oxlint

Found 0 warnings and 0 errors.
Finished in 10ms on 50 files using 8 threads.
```